### PR TITLE
Enhance Slack notification failure detection and expand Taskfile tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -38,6 +38,16 @@ tasks:
       - curl "http://127.0.0.1:8000/api/{{.COMPANY}}/{{.TYPE}}/start"
 
   test:
-    desc: Run all parser tests
+    desc: Run all tests in the test suite
     cmds:
-      - docker compose exec -T app pytest src/crawler/tests/unit/
+      - docker compose exec -T app pytest src/crawler/tests
+
+  test-slack:
+    desc: Run Slack utility unit tests
+    cmds:
+      - docker compose exec -T app pytest src/crawler/tests/unit/test_slack.py -v
+
+  test-slack-dispatch:
+    desc: Send a live Slack message to verify real-time notification dispatch
+    cmds:
+      - docker compose exec -T app python Temp/test_slack_dispatch.py

--- a/src/crawler/package/api/api.py
+++ b/src/crawler/package/api/api.py
@@ -511,8 +511,9 @@ class ApiAsyncProcBase(metaclass=ABCMeta):
             except asyncio.exceptions.TimeoutError as e:
                 if loop and loop.is_running():
                     loop.stop()
-                futures = asyncio.gather(*[self._run(url)])
-                runResult = loop.run_until_complete(futures)
+                if loop:
+                    futures = asyncio.gather(*[self._run(url)])
+                    runResult = loop.run_until_complete(futures)
         except Exception as e:
             raise e
         finally:
@@ -910,9 +911,11 @@ class ParseDetailPageAsyncBase(ApiAsyncProcBase):
                                     
                                     logging.info(msg)
                                     
-                                    # Slack送信を実行
+                                    # Slack送信を実行し、成否を明示的に判定・ログ記録する
                                     from package.utils.slack import send_slack_message
-                                    await send_slack_message(msg)
+                                    success = await send_slack_message(msg)
+                                    if not success:
+                                        logging.error(f"❌ [SLACK ERROR] Failed to send Slack alert for {item.propertyName} ({item.pageUrl})")
                             else:
                                 eval_record.analysis_status = "skipped_by_budget"
                                 await sync_to_async(eval_record.save)()


### PR DESCRIPTION
Check Slack dispatch success and log explicit error on failure. Add new tasks 'test', 'test-slack', and 'test-slack-dispatch' to Taskfile.yml.