### PR TITLE
fix: create dummy .env for docker-compose in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
 
       - name: Start containers and setup DB
         run: |
+          touch .env
           docker compose up -d --build
           # Wait for MySQL to be ready
           sleep 15


### PR DESCRIPTION
Fixes CI failure by ensuring .env exists before docker compose up